### PR TITLE
Fix intuition reset

### DIFF
--- a/project/sherLOCKED/Assets/Scripts/_preload/ScoreManager.cs
+++ b/project/sherLOCKED/Assets/Scripts/_preload/ScoreManager.cs
@@ -76,6 +76,7 @@ public class ScoreManager : MonoBehaviour
         levelTime = TimeSpan.Zero;
         correctAnswers = 0;
         currentInt = 0;
+        nextInt = 10;
         currentRep = maxRep;
         UIManager.Instance.ResetValues();
         QuestionManager.Instance.ClearList();


### PR DESCRIPTION
**Description of work.**
- The next amount of gained intuition is reset when the score manager is reset, stopping a bug where failing a level would cause the player to gain more int than normal when getting their nect question right. 
<!-- Description of work done -->

**To test:**
1. Fail a level
2. Reload and check the correct amount of int is gained given a correct answer. 

Fixes #125 
