### PR TITLE
Fix wrong button changing colour RE #149

### DIFF
--- a/project/sherLOCKED/Assets/Rooms/Misc/MainMenu.unity
+++ b/project/sherLOCKED/Assets/Rooms/Misc/MainMenu.unity
@@ -3766,6 +3766,12 @@ MonoBehaviour:
   levelSelectMenu: {fileID: 201798757}
   customizeMenu: {fileID: 676056322}
   creditsMenu: {fileID: 1406565016}
+  buttons:
+  - {fileID: 1343646979}
+  - {fileID: 1198231701}
+  - {fileID: 92819063}
+  - {fileID: 1951135330}
+  - {fileID: 846675922}
 --- !u!1 &1343646979
 GameObject:
   m_ObjectHideFlags: 0

--- a/project/sherLOCKED/Assets/Scripts/Menus/MainMenuController.cs
+++ b/project/sherLOCKED/Assets/Scripts/Menus/MainMenuController.cs
@@ -12,6 +12,8 @@ public class MainMenuController : MonoBehaviour
     public GameObject customizeMenu;
     public GameObject creditsMenu;
 
+    public GameObject[] buttons;
+
     public void Start() {
         MusicManager.Instance.PlayMenuMusic();
         SetLevelColours();
@@ -86,7 +88,6 @@ public class MainMenuController : MonoBehaviour
     }
 
     private void SetLevelColours() {
-        var buttons = GameObject.FindGameObjectsWithTag("LevelButton");
         for(int i = 0; i<buttons.Length; i++) {
             ColorBlock cb = buttons[i].GetComponent<Button>().colors;
             if (LevelManager.Instance.GetComplete(i+1)) {


### PR DESCRIPTION
**Description of work.**
Fix the wrong buttons changing colour when uploaded to simmer after a level has been completed. 

**To test:**
Complete level on build version. 

Fixes #149 
