### PR TITLE
Fix Sherry appearing on main menu if pause menu is used

### DIFF
--- a/project/sherLOCKED/Assets/Rooms/Level4/HallL4.unity
+++ b/project/sherLOCKED/Assets/Rooms/Level4/HallL4.unity
@@ -2203,9 +2203,8 @@ GameObject:
   - component: {fileID: 1385569494}
   - component: {fileID: 1385569493}
   - component: {fileID: 1385569495}
-  - component: {fileID: 1385569496}
   m_Layer: 0
-  m_Name: HallFlowerPot
+  m_Name: flowerPot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2301,25 +2300,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 0.5}
   m_EdgeRadius: 0
---- !u!114 &1385569496
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1385569492}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7d9baed10a47540ad9e3e898b6267a37, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  topAnswer: {fileID: 0}
-  middleAnswer: {fileID: 0}
-  bottomAnswer: {fileID: 0}
-  correctAnswer: {fileID: 0}
-  extraInfo: {fileID: 0}
-  questionUI: {fileID: 0}
-  wrongText: 'Whoops. It''s about making security as easy as possible for the user. '
 --- !u!1 &1435641936 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2306804121684800427, guid: aedfc4a250e174620ac12d655bd4d085,

--- a/project/sherLOCKED/Assets/Scripts/Menus/PauseMenuController.cs
+++ b/project/sherLOCKED/Assets/Scripts/Menus/PauseMenuController.cs
@@ -28,6 +28,7 @@ public class PauseMenuController : MonoBehaviour
 
     public void ReturnToMainMenu() {
         UIManager.Instance.SetGameUIVisible(false);
+        Destroy(GameObject.Find("sherry_b1(Clone)"));
         SceneManager.LoadScene("MainMenu");
     }
 }


### PR DESCRIPTION
**Description of work.**
Added a line to destroy the sherry object when the game is returned to the main menu via the pause menu. 

Also fixed an exception in the hall of case 4. 

**To test:**
1. Load up a level and return to the main menu.
2. Ensure sherry is not still there. 

Fixes #163 
