### PR TITLE
Fix a bug where ginny's question would not disappear RE #NONE

### DIFF
--- a/project/sherLOCKED/Assets/Scripts/UI/QuestionController.cs
+++ b/project/sherLOCKED/Assets/Scripts/UI/QuestionController.cs
@@ -5,9 +5,7 @@ using UnityEngine;
 public class QuestionController : MonoBehaviour
 {
     public void Resume() {
-        if (Time.timeScale == 0){
-            Time.timeScale = 1;
-            this.gameObject.SetActive(false);
-        }
+        Time.timeScale = 1;
+        this.gameObject.SetActive(false);
 	}
 }


### PR DESCRIPTION
**Description of work.**
If ginny was spoken to for her question on case 4, the window to answer
the question would not disappear when the close button was pressed.
There may be something to do with conflicting scripts setting the
timecale, so I've just removed the check that the timescale is 0,
  figuring that there's no harm in setting it to 1 if it's already that.

Note: This is hotfix, so it has already been uploaded to simmer prior to testing. 

**To test:**
1. Start level 4 and go talk to ginny in the ballroom


*There is no associated issue.*

